### PR TITLE
fix: 수강 신청 동시성 이슈 해결 및 코드 개선

### DIFF
--- a/src/main/java/com/tutorialsejong/courseregistration/common/exception/BadRequestException.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.tutorialsejong.courseregistration.common.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/exception/GlobalExceptionHandler.java
@@ -88,4 +88,11 @@ public class GlobalExceptionHandler {
         body.put("message", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
     }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<?> handleBadRequestException(BadRequestException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/registration/entity/CourseRegistration.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/registration/entity/CourseRegistration.java
@@ -10,10 +10,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "course_registration")
+@Table(name = "course_registration", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"student_id", "schedule_id"})
+})
 public class CourseRegistration {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tutorialsejong/courseregistration/wishlist/service/WishListService.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/wishlist/service/WishListService.java
@@ -1,6 +1,8 @@
 package com.tutorialsejong.courseregistration.wishlist.service;
 
-import com.tutorialsejong.courseregistration.common.exception.CheckUserException;
+import com.tutorialsejong.courseregistration.common.exception.AlreadyRegisteredException;
+import com.tutorialsejong.courseregistration.common.exception.BadRequestException;
+import com.tutorialsejong.courseregistration.common.exception.NotFoundException;
 import com.tutorialsejong.courseregistration.registration.repository.CourseRegistrationRepository;
 import com.tutorialsejong.courseregistration.schedule.entity.Schedule;
 import com.tutorialsejong.courseregistration.schedule.repository.ScheduleRepository;
@@ -41,7 +43,7 @@ public class WishListService {
                 .collect(Collectors.toList());
 
         if (wishList.isEmpty()) {
-            throw new CheckUserException("이미 신청된 관심과목이거나 수강신청된 과목이 포함되어있습니다.");
+            throw new AlreadyRegisteredException("이미 신청된 관심과목이거나 수강신청된 과목이 포함되어있습니다.");
         }
 
         wishListRepository.saveAll(wishList);
@@ -60,12 +62,12 @@ public class WishListService {
 
     public User checkExistUser(String studentId) {
         return userRepository.findByStudentId(studentId)
-                .orElseThrow(() -> new CheckUserException(studentId + "회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException(studentId + "회원이 존재하지 않습니다."));
     }
 
     public Schedule checkExistSchedule(Long scheduleId) {
         return scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new CheckUserException(scheduleId + "과목이 존재하지않습니다."));
+                .orElseThrow(() -> new NotFoundException(scheduleId + "과목이 존재하지않습니다."));
     }
 
     public void deleteWishList(String studentId, Long scheduleId) {
@@ -73,7 +75,7 @@ public class WishListService {
         Schedule schedule = checkExistSchedule(scheduleId);
 
         WishList wishList = wishListRepository.findByStudentIdAndScheduleId(user, schedule)
-                .orElseThrow(() -> new CheckUserException("신청하지 않은 과목입니다."));
+                .orElseThrow(() -> new BadRequestException("신청하지 않은 과목입니다."));
 
         wishListRepository.delete(wishList);
     }


### PR DESCRIPTION
## 📋 이슈 번호
close #60 

## ✅ 변경 사항
1. CourseRegistration 엔티티에 유니크 제약 조건 추가
   - student_id와 schedule_id 조합에 대한 유니크 제약 조건을 추가하여 데이터베이스 레벨에서 중복 등록을 방지

2. registerCourse 메서드 로직 개선
   - 기존의 중복 체크 로직 제거
   - DataIntegrityViolationException을 캐치하여 AlreadyRegisteredException으로 변환


## 📝 세부 설명
- 클라이언트에서 연속적으로 중복 요청을 보내는 경우 발생하는 동시성 이슈 해결
- 데이터베이스에 중복 데이터가 저장되는 문제 방지