### PR TITLE
feat: 동일한 학수번호 예외처리

### DIFF
--- a/src/main/java/com/tutorialsejong/courseregistration/registration/service/CourseRegistrationService.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/registration/service/CourseRegistrationService.java
@@ -33,12 +33,20 @@ public class CourseRegistrationService {
 
     @Transactional
     public CourseRegistrationResponse registerCourse(String studentId, Long scheduleId) {
-        try {
-            User student = userRepository.findByStudentId(studentId)
-                    .orElseThrow(() -> new NotFoundException("User not found with id: " + studentId));
-            Schedule schedule = scheduleRepository.findById(scheduleId)
-                    .orElseThrow(() -> new NotFoundException("Schedule not found with id: " + scheduleId));
+        User student = userRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new NotFoundException("User not found with id: " + studentId));
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new NotFoundException("Schedule not found with id: " + scheduleId));
 
+        boolean alreadyRegistered = courseRegistrationRepository.findAllByStudent(student)
+                .stream()
+                .anyMatch(registration -> registration.getSchedule().getCuriNo().equals(schedule.getCuriNo()));
+
+        if (alreadyRegistered) {
+            throw new AlreadyRegisteredException("Course already registered");
+        }
+
+        try {
             CourseRegistration registration = new CourseRegistration(student, schedule, LocalDateTime.now());
             registration = courseRegistrationRepository.save(registration);
             return convertToDto(registration);

--- a/src/main/java/com/tutorialsejong/courseregistration/wishlist/controller/WishListController.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/wishlist/controller/WishListController.java
@@ -23,8 +23,8 @@ public class WishListController {
 
 
     @PostMapping("/save")
-    public ResponseEntity<?> saveWishList(@RequestBody WishListRequest wishListRequest) {
-        wishListService.saveWishList(wishListRequest.studentId(), wishListRequest.wishListIdList());
+    public ResponseEntity<?> saveWishListItem(@RequestBody WishListRequest wishListRequest) {
+        wishListService.saveWishListItem(wishListRequest.studentId(), wishListRequest.scheduleId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body("관심과목이 저장되었습니다.");
     }
@@ -37,8 +37,8 @@ public class WishListController {
     }
 
     @DeleteMapping
-    public ResponseEntity<?> deleteWishList(@RequestParam String studentId, @RequestParam Long scheduleId) {
-        wishListService.deleteWishList(studentId, scheduleId);
+    public ResponseEntity<?> deleteWishListItem(@RequestParam String studentId, @RequestParam Long scheduleId) {
+        wishListService.deleteWishListItem(studentId, scheduleId);
         return ResponseEntity.status(HttpStatus.OK).body("관심과목이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/wishlist/dto/WishListRequest.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/wishlist/dto/WishListRequest.java
@@ -1,10 +1,8 @@
 package com.tutorialsejong.courseregistration.wishlist.dto;
 
 
-import java.util.List;
-
 public record WishListRequest(
         String studentId,
-        List<Long> wishListIdList
+        Long scheduleId
 ) {
 }


### PR DESCRIPTION
## 📋 이슈 번호
close #66 

## ✅ 변경 사항
- 기존에는 관심과목 담기, 수강신청 api에서 scheduleId로만 AlreadyRegisteredException 예외 처리를 하였는데
- 동일한 학수번호(curiNo)로 등록된 목록이 있을 경우도 AlreadyRegisteredException 처리를 하도록 변경했습니다.
- 관심과목 담기(post `/wishlist/save`) 시 list로 id를 전달 받던 것을 scheduleId 하나만을 전달 받도록 변경했습니다.
