### PR TITLE
refactor(TS-21): JWT 인증 예외 처리 개선

### DIFF
--- a/src/main/java/com/tutorialsejong/courseregistration/common/config/JacksonConfig.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.tutorialsejong.courseregistration.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/common/config/SecurityConfig.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/config/SecurityConfig.java
@@ -2,9 +2,10 @@ package com.tutorialsejong.courseregistration.common.config;
 
 import com.tutorialsejong.courseregistration.common.security.JwtAuthenticationEntryPoint;
 import com.tutorialsejong.courseregistration.common.security.JwtAuthenticationFilter;
+import com.tutorialsejong.courseregistration.common.security.JwtExceptionFilter;
 import com.tutorialsejong.courseregistration.common.security.JwtTokenProvider;
-import com.tutorialsejong.courseregistration.domain.auth.service.CustomUserDetailsService;
 import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -19,20 +20,12 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
     private final JwtTokenProvider tokenProvider;
-    private final CustomUserDetailsService customUserDetailsService;
-    private final JwtAuthenticationEntryPoint unauthorizedHandler;
-
-    public SecurityConfig(JwtTokenProvider tokenProvider, JwtAuthenticationEntryPoint unauthorizedHandler,
-                          CustomUserDetailsService customUserDetailsService) {
-        this.tokenProvider = tokenProvider;
-        this.unauthorizedHandler = unauthorizedHandler;
-        this.customUserDetailsService = customUserDetailsService;
-    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -65,10 +58,11 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandling -> exceptionHandling
-                        .authenticationEntryPoint(unauthorizedHandler)
+                        .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(tokenProvider, customUserDetailsService),
-                        UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(tokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/tutorialsejong/courseregistration/common/exception/ErrorResponse.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/exception/ErrorResponse.java
@@ -3,7 +3,11 @@ package com.tutorialsejong.courseregistration.common.exception;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.tutorialsejong.courseregistration.common.utils.JsonUtils;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.List;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 
@@ -23,8 +27,15 @@ public record ErrorResponse(
         return new ErrorResponse(errorCode, invalidParams);
     }
 
-    public ResponseEntity<Object> asHttp() {
+    public ResponseEntity<Object> toResponseEntity() {
         return ResponseEntity.status(errorCode.getStatus()).body(this);
+    }
+
+    public void writeTo(HttpServletResponse response) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(JsonUtils.toJson(this));
     }
 
     public record InvalidParam(String name, String reason) {

--- a/src/main/java/com/tutorialsejong/courseregistration/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.tutorialsejong.courseregistration.common.exception;
 
-import com.tutorialsejong.courseregistration.common.security.exception.JwtAuthenticationException;
-import io.jsonwebtoken.ExpiredJwtException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -10,7 +8,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -22,8 +19,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<Object> handleBusinessException(BusinessException ex) {
-        ErrorCode errorCode = ex.getErrorCode();
-        return ErrorResponse.from(errorCode).asHttp();
+        return ErrorResponse.from(ex.getErrorCode()).toResponseEntity();
     }
 
     @Override
@@ -38,15 +34,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .map(ErrorResponse.InvalidParam::from)
                 .toList();
 
-        ErrorCode errorCode = GlobalErrorCode.INVALID_INPUT_VALUE;
-        return ErrorResponse.of(errorCode, invalidParams).asHttp();
-    }
-
-    @ExceptionHandler(BadCredentialsException.class)
-    public ResponseEntity<?> handleBadCredentialsException(BadCredentialsException ex) {
-        Map<String, Object> body = new HashMap<>();
-        body.put("message", "올바르지 않은 비밀번호입니다!");
-        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(body);
+        return ErrorResponse.of(GlobalErrorCode.INVALID_INPUT_VALUE, invalidParams).toResponseEntity();
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
@@ -56,20 +44,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 
-    @ExceptionHandler(JwtAuthenticationException.class)
-    public ResponseEntity<?> handleJwtAuthenticationException(JwtAuthenticationException ex) {
-        Map<String, Object> body = new HashMap<>();
-        if (ex.getCause() instanceof ExpiredJwtException) {
-            body.put("message", Collections.singletonList("토큰이 만료되었습니다."));
-        } else {
-            body.put("message", Collections.singletonList("유효하지 않은 토큰입니다."));
-        }
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
-    }
-
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleGenericException(Exception ex) {
-        ErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
-        return ErrorResponse.from(errorCode).asHttp();
+        return ErrorResponse.from(GlobalErrorCode.INTERNAL_SERVER_ERROR).toResponseEntity();
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtAuthenticationEntryPoint.java
@@ -1,10 +1,10 @@
 package com.tutorialsejong.courseregistration.common.security;
 
+import com.tutorialsejong.courseregistration.common.exception.ErrorResponse;
+import com.tutorialsejong.courseregistration.common.security.exception.SecurityErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -12,14 +12,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationEntryPoint.class);
-
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
-        logger.error("Unauthorized error: {}", authException.getMessage());
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json");
-        response.getWriter().write(String.format("{\"error\": \"Unauthorized: %s\"}", authException.getMessage()));
+        ErrorResponse.from(SecurityErrorCode.AUTHENTICATION_FAILED)
+                .writeTo(response);
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtAuthenticationFilter.java
@@ -1,13 +1,12 @@
 package com.tutorialsejong.courseregistration.common.security;
 
-import com.tutorialsejong.courseregistration.common.security.exception.JwtAuthenticationException;
-import com.tutorialsejong.courseregistration.domain.auth.service.CustomUserDetailsService;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,58 +14,44 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtTokenProvider tokenProvider;
-    private final CustomUserDetailsService userDetailsService;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
 
-    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider, CustomUserDetailsService userDetailsService) {
-        this.tokenProvider = tokenProvider;
-        this.userDetailsService = userDetailsService;
-    }
+    private final JwtTokenProvider tokenProvider;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        try {
-            String jwt = getJwtFromRequest(request);
-            if (StringUtils.hasText(jwt)) {
-                tokenProvider.validateToken(jwt);
-                Authentication authentication = tokenProvider.getAuthentication(jwt);
+        extractJwtFromRequest(request)
+                .ifPresent(jwt -> processJwtAuthentication(jwt, request));
 
-                if (authentication instanceof UsernamePasswordAuthenticationToken) {
-                    ((UsernamePasswordAuthenticationToken) authentication)
-                            .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                }
-
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
-            filterChain.doFilter(request, response);
-        } catch (ExpiredJwtException ex) {
-            logger.error("Expired JWT token", ex);
-            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "Access Token has expired");
-        } catch (JwtAuthenticationException ex) {
-            logger.error("Invalid JWT token", ex);
-            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "Invalid Access Token");
-        } catch (Exception ex) {
-            logger.error("Could not set user authentication in security context", ex);
-            sendErrorResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                    "An error occurred while processing your request");
-        }
+        filterChain.doFilter(request, response);
     }
 
-    private void sendErrorResponse(HttpServletResponse response, int status, String message) throws IOException {
-        response.setStatus(status);
-        response.setContentType("application/json");
-        response.getWriter().write(String.format("{\"error\": \"%s\"}", message));
+    private Optional<String> extractJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return Optional.of(bearerToken.substring(BEARER_PREFIX_LENGTH));
+        }
+        return Optional.empty();
     }
 
-    private String getJwtFromRequest(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
+    private void processJwtAuthentication(String jwt, HttpServletRequest request) {
+        tokenProvider.validateToken(jwt);
+        Authentication authentication = tokenProvider.getAuthentication(jwt);
+        enhanceAuthenticationWithRequestDetails(authentication, request);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private void enhanceAuthenticationWithRequestDetails(Authentication authentication, HttpServletRequest request) {
+        if (authentication instanceof UsernamePasswordAuthenticationToken) {
+            ((UsernamePasswordAuthenticationToken) authentication)
+                    .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         }
-        return null;
     }
 
     @Override

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtExceptionFilter.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtExceptionFilter.java
@@ -1,0 +1,24 @@
+package com.tutorialsejong.courseregistration.common.security;
+
+import com.tutorialsejong.courseregistration.common.exception.ErrorResponse;
+import com.tutorialsejong.courseregistration.common.security.exception.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException e) {
+            ErrorResponse.from(e.getErrorCode())
+                    .writeTo(response);
+        }
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.tutorialsejong.courseregistration.common.security;
 
-import com.tutorialsejong.courseregistration.common.security.exception.JwtAuthenticationException;
+import com.tutorialsejong.courseregistration.common.security.exception.JwtTokenExpiredException;
+import com.tutorialsejong.courseregistration.common.security.exception.JwtTokenInvalidException;
 import com.tutorialsejong.courseregistration.domain.auth.service.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -57,9 +58,6 @@ public class JwtTokenProvider {
     }
 
     public String generateAccessTokenFromUsername(String username) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + accessTokenExpirationInMs);
-
         return generateToken(username, accessTokenExpirationInMs);
     }
 
@@ -74,13 +72,13 @@ public class JwtTokenProvider {
         return claims.getSubject();
     }
 
-    public void validateToken(String authToken) {
+    public void validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(authToken);
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
         } catch (ExpiredJwtException ex) {
-            throw ex;
+            throw new JwtTokenExpiredException();
         } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException ex) {
-            throw new JwtAuthenticationException("Invalid JWT token", ex);
+            throw new JwtTokenInvalidException();
         }
     }
 

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/JwtAuthenticationException.java
@@ -1,8 +1,0 @@
-package com.tutorialsejong.courseregistration.common.security.exception;
-
-public class JwtAuthenticationException extends RuntimeException {
-    
-    public JwtAuthenticationException(String message, Throwable cause) {
-        super(message, cause);
-    }
-}

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/JwtException.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/JwtException.java
@@ -1,0 +1,21 @@
+package com.tutorialsejong.courseregistration.common.security.exception;
+
+import com.tutorialsejong.courseregistration.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class JwtException extends AuthenticationException {
+
+    private final ErrorCode errorCode;
+
+    public JwtException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public JwtException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/JwtTokenExpiredException.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/JwtTokenExpiredException.java
@@ -1,0 +1,8 @@
+package com.tutorialsejong.courseregistration.common.security.exception;
+
+public class JwtTokenExpiredException extends JwtException {
+
+    public JwtTokenExpiredException() {
+        super(SecurityErrorCode.JWT_TOKEN_EXPIRED);
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/JwtTokenInvalidException.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/JwtTokenInvalidException.java
@@ -1,0 +1,8 @@
+package com.tutorialsejong.courseregistration.common.security.exception;
+
+public class JwtTokenInvalidException extends JwtException {
+
+    public JwtTokenInvalidException() {
+        super(SecurityErrorCode.JWT_TOKEN_INVALID);
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/SecurityErrorCode.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/SecurityErrorCode.java
@@ -1,0 +1,20 @@
+package com.tutorialsejong.courseregistration.common.security.exception;
+
+import com.tutorialsejong.courseregistration.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SecurityErrorCode implements ErrorCode {
+
+    AUTHENTICATION_FAILED("S001", "인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    JWT_TOKEN_EXPIRED("S002", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    JWT_TOKEN_INVALID("S003", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/common/utils/JsonUtils.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/utils/JsonUtils.java
@@ -1,0 +1,21 @@
+package com.tutorialsejong.courseregistration.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonUtils {
+    
+    private static ObjectMapper objectMapper;
+
+    @Autowired
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        JsonUtils.objectMapper = objectMapper;
+    }
+
+    public static String toJson(Object object) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(object);
+    }
+}


### PR DESCRIPTION
## 이슈
[TS-21](https://jeez.atlassian.net/jira/software/projects/TS/boards/1?selectedIssue=TS-21)

## 주요 변경 사항
> spring security의 인증 과정 예외처리를 기존의 error response의 형식을 일관되게 따를 수 있도록 변경했습니다.

1. `JwtExceptionFilter` 구현
   - JWT 토큰 관련 예외(`JwtException`)를 처리합니다.
   - 클라이언트에게 일관된 형식의 에러 응답을 제공합니다.

2. `JwtAuthenticationEntryPoint` 구현
   - Spring Security의 `AuthenticationException`을 처리합니다.
   - 클라이언트에게 일관된 형식의 에러 응답을 제공합니다.

3. `SecurityConfig` 수정
   - 새로 구현한 `JwtExceptionFilter`를 필터 체인에 추가했습니다.
   - `JwtAuthenticationEntryPoint`를 수정하고 Spring Security의 예외 처리 메커니즘에 연결했습니다.

## 세부 설명

이번 리팩토링을 하면서 spring security의 필터 체인에 대해서 공부할 수 있었습니다!

Spring Security의 인증 과정은 필터 단계에서 이루어지며, 이는 Controller, DispatcherServlet 보다 앞단에 위치하는데요. 

![image](https://github.com/user-attachments/assets/f5ced82a-878c-46dc-a979-6e527eaa683e)

때문에 jwt 인증 로직과 인증 로직의 예외 처리 로직도 필터로 구현되어 Spring Security의 filter chain에 연결 되어야 합니다. 

이러한 이유로 다음과 같은 컴포넌트들을 새로 구현, 리팩토링 하였습니다:

- 새로 구현한 `JwtExceptionFilter`를 `UsernamePasswordAuthenticationFilter` 이전의 필터 체인에 추가했습니다.
- `JwtAuthenticationEntryPoint`를 Spring Security의 `exceptionHandling()` 설정을 통해 인증 실패 처리 지점으로 지정했습니다.

이 두 컴포넌트를 `SecurityConfig`에서 필터 체인의 적절한 위치에 배치하여 
인증 과정에서 발생하는 모든 예외를 일관되게 처리할 수 있게 되었습니다.

현재 구현한 filter chain의 대략적인 그림입니다.

![](https://velog.velcdn.com/images/zhy2on/post/3aeb6803-29af-46d3-9cb6-78edb763f036/image.png)

아래는 공부하면서 적어본 글들입니다..!

> [🏁 1](https://velog.io/@zhy2on/그림일기-서비스-보고-공부하기-OncePerRequestFilter와-AuthenticationEntryPoint)
만료된 토큰으로 요청시 토큰 만료에 대한 응답을 해주기 위해서라도 OncePerRequestFilter를 extends한 JwtExceptionFilter를 구현해야겠다고 생각했습니다.
[🏁 2](https://velog.io/@zhy2on/그림일기-서비스-보고-공부하기-addFilterBefore-순서)
익셉션의 전파는 상위 레이어로 전달되기 때문에 exception filter가 authentication filter 보다 앞에 위치해야 한다는 것을 짚고 넘어갈 수 있었습니다.
[🏁 3](https://velog.io/@zhy2on/그림일기-서비스-보고-공부하기-JwtExceptionFilter와-JwtAuthenticationEntryPoint를-모두-구현해야할-것-같다)
JwtException이 아닌 AuthenticationException까지 일관되게 처리해주기 위해서는 JwtAuthenticationEntryPoint도 구현해줘야겠다고 생각하게 됐습니다.
[🏁 4](https://velog.io/@zhy2on/그림일기-서비스-보고-공부하기-JwtAuthenticationEntryPoint에만-Component를-붙이는-이유-OncePerRequestFilter-vs-AuthenticationEntryPoint-2탄)
서블릿 컨테이너가 관리하는 OncePerRequestFilter와 스프링 빈으로 관리되는 AuthenticationEntryPoint의 차이점에 대해 명확히 이해할 수 있게 됐습니다.

[TS-21]: https://jeez.atlassian.net/browse/TS-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ