### PR TITLE
refactor(TS-27): AuthController와 UserController 역할 분리 및 회원 탈퇴 api 리팩토링

### DIFF
--- a/src/main/java/com/tutorialsejong/courseregistration/common/config/SecurityConfig.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/config/SecurityConfig.java
@@ -52,8 +52,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/login",
-                                "/api/auth/refresh",
-                                "/api/auth/withdrawal/**"
+                                "/api/auth/refresh"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtAuthenticationFilter.java
@@ -57,6 +57,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return path.equals("/api/auth/login") || path.equals("/api/auth/refresh") || path.equals("/api/auth/withdraw");
+        return path.equals("/api/auth/login") || path.equals("/api/auth/refresh");
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/controller/AuthController.java
@@ -8,101 +8,48 @@ import com.tutorialsejong.courseregistration.domain.auth.dto.MacroResponse;
 import com.tutorialsejong.courseregistration.domain.auth.service.AuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
+
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-    private static final String COOKIE_PATH = "/";
-    private static final List<Integer> MACRO_ANSWERS = Arrays.asList(
-            1208, 2154, 2509, 2857, 3086,
-            3458, 3511, 3803, 4613, 4139,
-            5106, 5802, 5648, 6352, 7086,
-            7414, 8415, 8594, 9468, 9102,
-            1146, 1452, 2117, 3964, 4586,
-            5148, 5549, 6180, 7597, 9383
-    );
 
     private final AuthService authService;
 
-    @Value("${app.jwt.refreshTokenExpirationInMs}")
-    private int refreshTokenExpirationInMs;
-
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
-
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody @Valid LoginRequest loginRequest, HttpServletResponse response) {
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest loginRequest,
+                                               HttpServletResponse response) {
         AuthenticationResult authResult = authService.loginOrSignup(loginRequest);
-        ResponseCookie refreshTokenCookie = createRefreshTokenCookie(authResult.refreshToken());
-
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
-
-        LoginResponse loginResponse = new LoginResponse(authResult.accessToken(), authResult.username());
-        return ResponseEntity.ok(loginResponse);
+        setRefreshTokenCookie(response, authResult.refreshToken());
+        return ResponseEntity.ok(new LoginResponse(authResult.accessToken(), authResult.username()));
     }
 
 
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
-        if (refreshToken == null) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Refresh token is missing");
-        }
-
-        JwtTokens jwtTokens = authService.refreshAccessToken(refreshToken);
-        Map<String, Object> body = new HashMap<>();
-        body.put("accessToken", jwtTokens.accessToken());
-        return ResponseEntity.ok().body(body);
-    }
-
-    @DeleteMapping("/withdrawal/{studentId}")
-    public ResponseEntity<?> withdrawal(@PathVariable("studentId") String studentId) {
-
-        authService.withdrawalUser(studentId);
-
-        return ResponseEntity.ok().build();
+    public ResponseEntity<?> refreshToken(
+            @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
+        JwtTokens tokens = authService.refreshToken(refreshToken);
+        return ResponseEntity.ok(tokens);
     }
 
     @GetMapping("/macro")
-    public ResponseEntity<?> verificationCodes() {
-        MacroResponse body = createMacroResponse();
-        return ResponseEntity.ok(body);
+    public ResponseEntity<MacroResponse> verificationCodes() {
+        MacroResponse macroResponse = authService.generateMacroResponse();
+        return ResponseEntity.ok(macroResponse);
     }
 
-    private ResponseCookie createRefreshTokenCookie(String refreshToken) {
-        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .maxAge(Duration.ofMillis(refreshTokenExpirationInMs))
-                .path(COOKIE_PATH)
-                .build();
-    }
-
-    private MacroResponse createMacroResponse() {
-        Random random = new Random();
-        int randomNumber = random.nextInt(30) + 1;
-
-        MacroResponse.MacroData data = new MacroResponse.MacroData(
-                MACRO_ANSWERS.get(randomNumber - 1).toString(),
-                "/macro/" + randomNumber + ".jpg"
-        );
-
-        return new MacroResponse(200, data);
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        response.addHeader(HttpHeaders.SET_COOKIE, authService.createRefreshTokenCookie(refreshToken).toString());
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/dto/JwtTokens.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/dto/JwtTokens.java
@@ -2,5 +2,6 @@ package com.tutorialsejong.courseregistration.domain.auth.dto;
 
 public record JwtTokens(
         String accessToken,
-        String refreshToken) {
+        String refreshToken
+) {
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/dto/LoginResponse.java
@@ -2,5 +2,6 @@ package com.tutorialsejong.courseregistration.domain.auth.dto;
 
 public record LoginResponse(
         String accessToken,
-        String username) {
+        String username
+) {
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,19 @@
+package com.tutorialsejong.courseregistration.domain.auth.exception;
+
+import com.tutorialsejong.courseregistration.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    AUTHENTICATION_FAILED("A001", "아이디 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("A002", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/exception/InvalidLoginException.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/exception/InvalidLoginException.java
@@ -1,0 +1,10 @@
+package com.tutorialsejong.courseregistration.domain.auth.exception;
+
+import com.tutorialsejong.courseregistration.common.exception.BusinessException;
+
+public class InvalidLoginException extends BusinessException {
+    
+    public InvalidLoginException() {
+        super(AuthErrorCode.AUTHENTICATION_FAILED);
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.tutorialsejong.courseregistration.domain.auth.exception;
+
+import com.tutorialsejong.courseregistration.common.exception.BusinessException;
+
+public class InvalidRefreshTokenException extends BusinessException {
+
+    public InvalidRefreshTokenException() {
+        super(AuthErrorCode.INVALID_REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/service/AuthService.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/service/AuthService.java
@@ -4,50 +4,101 @@ import com.tutorialsejong.courseregistration.common.security.JwtTokenProvider;
 import com.tutorialsejong.courseregistration.domain.auth.dto.AuthenticationResult;
 import com.tutorialsejong.courseregistration.domain.auth.dto.JwtTokens;
 import com.tutorialsejong.courseregistration.domain.auth.dto.LoginRequest;
-import com.tutorialsejong.courseregistration.domain.registration.service.CourseRegistrationService;
+import com.tutorialsejong.courseregistration.domain.auth.dto.MacroResponse;
+import com.tutorialsejong.courseregistration.domain.auth.exception.InvalidLoginException;
+import com.tutorialsejong.courseregistration.domain.auth.exception.InvalidRefreshTokenException;
 import com.tutorialsejong.courseregistration.domain.user.entity.User;
 import com.tutorialsejong.courseregistration.domain.user.exception.UserNotFoundException;
-import com.tutorialsejong.courseregistration.domain.user.repository.InvalidRefreshTokenException;
 import com.tutorialsejong.courseregistration.domain.user.repository.UserRepository;
-import com.tutorialsejong.courseregistration.domain.wishlist.service.WishListService;
-import jakarta.transaction.Transactional;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class AuthService {
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final String COOKIE_PATH = "/";
+    private static final List<Integer> MACRO_ANSWERS = Arrays.asList(
+            1208, 2154, 2509, 2857, 3086,
+            3458, 3511, 3803, 4613, 4139,
+            5106, 5802, 5648, 6352, 7086,
+            7414, 8415, 8594, 9468, 9102,
+            1146, 1452, 2117, 3964, 4586,
+            5148, 5549, 6180, 7597, 9383
+    );
+
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider tokenProvider;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    private final WishListService wishListService;
+    @Value("${app.jwt.refreshTokenExpirationInMs}")
+    private int refreshTokenExpirationInMs;
 
-    private final CourseRegistrationService courseRegistrationService;
-
-    public AuthService(AuthenticationManager authenticationManager,
-                       JwtTokenProvider tokenProvider,
-                       UserRepository userRepository,
-                       PasswordEncoder passwordEncoder, WishListService wishListService,
-                       CourseRegistrationService courseRegistrationService) {
-        this.authenticationManager = authenticationManager;
-        this.tokenProvider = tokenProvider;
-        this.userRepository = userRepository;
-        this.passwordEncoder = passwordEncoder;
-
-        this.wishListService = wishListService;
-        this.courseRegistrationService = courseRegistrationService;
+    @Transactional
+    public AuthenticationResult loginOrSignup(LoginRequest loginRequest) {
+        try {
+            User user = findOrCreateUser(loginRequest);
+            Authentication authentication = authenticate(loginRequest);
+            JwtTokens jwtTokens = generateTokens(authentication, user);
+            return new AuthenticationResult(jwtTokens.accessToken(), jwtTokens.refreshToken(), user.getStudentId());
+        } catch (BadCredentialsException e) {
+            throw new InvalidLoginException();
+        }
     }
 
-    public AuthenticationResult loginOrSignup(LoginRequest loginRequest) {
-        User user = findOrCreateUser(loginRequest);
-        Authentication authentication = authenticate(loginRequest);
-        JwtTokens jwtTokens = generateTokens(authentication, user);
-        return new AuthenticationResult(jwtTokens.accessToken(), jwtTokens.refreshToken(), user.getStudentId());
+    @Transactional
+    public JwtTokens refreshToken(String refreshToken) {
+        if (refreshToken == null) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        String username = tokenProvider.getUsernameFromJWT(refreshToken);
+        User user = userRepository.findByStudentId(username)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!user.getRefreshToken().equals(refreshToken)) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        String newAccessToken = tokenProvider.generateAccessTokenFromUsername(username);
+        return new JwtTokens(newAccessToken, refreshToken);
+    }
+
+    public MacroResponse generateMacroResponse() {
+        Random random = new Random();
+        int randomNumber = random.nextInt(30) + 1;
+
+        MacroResponse.MacroData data = new MacroResponse.MacroData(
+                MACRO_ANSWERS.get(randomNumber - 1).toString(),
+                "/macro/" + randomNumber + ".jpg"
+        );
+
+        return new MacroResponse(200, data);
+    }
+
+    public ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(Duration.ofMillis(refreshTokenExpirationInMs))
+                .path(COOKIE_PATH)
+                .build();
     }
 
     private User findOrCreateUser(LoginRequest loginRequest) {
@@ -83,27 +134,5 @@ public class AuthService {
         userRepository.save(user);
 
         return new JwtTokens(accessToken, refreshToken);
-    }
-
-    public JwtTokens refreshAccessToken(String refreshToken) {
-        String username = tokenProvider.getUsernameFromJWT(refreshToken);
-
-        User user = userRepository.findByStudentId(username)
-                .orElseThrow(() -> new UserNotFoundException());
-
-        if (!user.getRefreshToken().equals(refreshToken)) {
-            throw new InvalidRefreshTokenException("Invalid refresh token");
-        }
-
-        String newAccessToken = tokenProvider.generateAccessTokenFromUsername(username);
-        return new JwtTokens(newAccessToken, refreshToken);
-    }
-
-    @Transactional
-    public void withdrawalUser(String studentId) {
-
-        wishListService.deleteWishListsByStudent(studentId);
-        courseRegistrationService.deleteCourseRegistrationsByStudent(studentId);
-        userRepository.deleteByStudentId(studentId);
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/user/controller/UserController.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/user/controller/UserController.java
@@ -1,0 +1,24 @@
+package com.tutorialsejong.courseregistration.domain.user.controller;
+
+import com.tutorialsejong.courseregistration.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @DeleteMapping("/me")
+    public ResponseEntity<?> withdrawUser(@AuthenticationPrincipal UserDetails userDetails) {
+        userService.withdrawUser(userDetails.getUsername());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/user/repository/InvalidRefreshTokenException.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/user/repository/InvalidRefreshTokenException.java
@@ -1,7 +1,0 @@
-package com.tutorialsejong.courseregistration.domain.user.repository;
-
-public class InvalidRefreshTokenException extends RuntimeException {
-    public InvalidRefreshTokenException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/user/service/UserService.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/user/service/UserService.java
@@ -1,0 +1,25 @@
+package com.tutorialsejong.courseregistration.domain.user.service;
+
+import com.tutorialsejong.courseregistration.domain.registration.service.CourseRegistrationService;
+import com.tutorialsejong.courseregistration.domain.user.repository.UserRepository;
+import com.tutorialsejong.courseregistration.domain.wishlist.service.WishListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final WishListService wishListService;
+    private final CourseRegistrationService courseRegistrationService;
+
+    @Transactional
+    public void withdrawUser(String studentId) {
+        wishListService.deleteWishListsByStudent(studentId);
+        courseRegistrationService.deleteCourseRegistrationsByStudent(studentId);
+        userRepository.deleteByStudentId(studentId);
+//        invalidateUserTokens(username); 토큰 무효화 구현 필요
+    }
+}


### PR DESCRIPTION
## 📋 이슈 번호
- [TS-27](https://jeez.atlassian.net/jira/software/projects/TS/boards/1?selectedIssue=TS-27)

## ✅ 변경 사항
- AuthController에서 로그인 및 토큰 갱신 관련 메서드 유지
- 회원 탈퇴 기능을 UserController로 이동하여 책임 분리
- SecurityConfig에서 허용할 api 목록 중 회원탈퇴 api 제거
- 회원 탈퇴 api 이름 변경 -> DELETE /api/users/me

## 📝 세부 설명
AuthController에는 인증 관련 로직만 남겨두고
회원 탈퇴 기능은 UserController로 이동했습니다.
또한 회원탈퇴 api 이름을 개선하였습니다.

[TS-27]: https://jeez.atlassian.net/browse/TS-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ