### PR TITLE
refactor(TS-35): 매크로 방지 이미지 생성을 Simple Captcha를 이용하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'org.projectlombok:lombok'
-    
+    implementation 'cn.apiclub.tool:simplecaptcha:1.2.2'
+
     annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/tutorialsejong/courseregistration/common/config/CaptchaConfig.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/config/CaptchaConfig.java
@@ -1,0 +1,31 @@
+package com.tutorialsejong.courseregistration.common.config;
+
+import cn.apiclub.captcha.backgrounds.BackgroundProducer;
+import cn.apiclub.captcha.backgrounds.GradiatedBackgroundProducer;
+import cn.apiclub.captcha.text.renderer.DefaultWordRenderer;
+import cn.apiclub.captcha.text.renderer.WordRenderer;
+import java.awt.Color;
+import java.awt.Font;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CaptchaConfig {
+
+    @Bean
+    public WordRenderer wordRenderer() {
+        return new DefaultWordRenderer(
+                List.of(new Color(0, 0, 0)),
+                List.of(new Font("Helvetica", Font.PLAIN, 60))
+        );
+    }
+
+    @Bean
+    public BackgroundProducer backgroundProducer() {
+        GradiatedBackgroundProducer producer = new GradiatedBackgroundProducer();
+        producer.setFromColor(new Color(100, 100, 100));
+        producer.setToColor(new Color(180, 180, 180));
+        return producer;
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/controller/AuthController.java
@@ -1,51 +1,46 @@
 package com.tutorialsejong.courseregistration.domain.auth.controller;
 
 import com.tutorialsejong.courseregistration.domain.auth.dto.AuthenticationResult;
+import com.tutorialsejong.courseregistration.domain.auth.dto.CaptchaResult;
 import com.tutorialsejong.courseregistration.domain.auth.dto.JwtTokens;
 import com.tutorialsejong.courseregistration.domain.auth.dto.LoginRequest;
 import com.tutorialsejong.courseregistration.domain.auth.dto.LoginResponse;
 import com.tutorialsejong.courseregistration.domain.auth.dto.MacroResponse;
 import com.tutorialsejong.courseregistration.domain.auth.service.AuthService;
+import com.tutorialsejong.courseregistration.domain.auth.service.CaptchaService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Random;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
 
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
     private static final String COOKIE_PATH = "/";
-    private static final List<Integer> MACRO_ANSWERS = Arrays.asList(
-            1208, 2154, 2509, 2857, 3086,
-            3458, 3511, 3803, 4613, 4139,
-            5106, 5802, 5648, 6352, 7086,
-            7414, 8415, 8594, 9468, 9102,
-            1146, 1452, 2117, 3964, 4586,
-            5148, 5549, 6180, 7597, 9383
-    );
 
     private final AuthService authService;
+    private final CaptchaService captchaService;
 
     @Value("${app.jwt.refreshTokenExpirationInMs}")
     private int refreshTokenExpirationInMs;
-
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid LoginRequest loginRequest, HttpServletResponse response) {
@@ -57,7 +52,6 @@ public class AuthController {
         LoginResponse loginResponse = new LoginResponse(authResult.accessToken(), authResult.username());
         return ResponseEntity.ok(loginResponse);
     }
-
 
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
@@ -80,9 +74,9 @@ public class AuthController {
     }
 
     @GetMapping("/macro")
-    public ResponseEntity<?> verificationCodes() {
-        MacroResponse body = createMacroResponse();
-        return ResponseEntity.ok(body);
+    public ResponseEntity<?> getMacro() {
+        CaptchaResult captchaData = captchaService.generateCaptcha();
+        return ResponseEntity.ok(new MacroResponse(200, captchaData));
     }
 
     private ResponseCookie createRefreshTokenCookie(String refreshToken) {
@@ -93,17 +87,5 @@ public class AuthController {
                 .maxAge(Duration.ofMillis(refreshTokenExpirationInMs))
                 .path(COOKIE_PATH)
                 .build();
-    }
-
-    private MacroResponse createMacroResponse() {
-        Random random = new Random();
-        int randomNumber = random.nextInt(30) + 1;
-
-        MacroResponse.MacroData data = new MacroResponse.MacroData(
-                MACRO_ANSWERS.get(randomNumber - 1).toString(),
-                "/macro/" + randomNumber + ".jpg"
-        );
-
-        return new MacroResponse(200, data);
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/dto/CaptchaResult.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/dto/CaptchaResult.java
@@ -1,0 +1,7 @@
+package com.tutorialsejong.courseregistration.domain.auth.dto;
+
+public record CaptchaResult(
+        String answer,
+        String url
+) {
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/dto/MacroResponse.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/dto/MacroResponse.java
@@ -1,53 +1,7 @@
 package com.tutorialsejong.courseregistration.domain.auth.dto;
 
-public class MacroResponse {
-    private Integer statusCode;
-    private MacroData data;
-
-    public MacroResponse(Integer statusCode, MacroData data) {
-        this.statusCode = statusCode;
-        this.data = data;
-    }
-
-    public Integer getStatusCode() {
-        return statusCode;
-    }
-
-    public void setStatusCode(Integer statusCode) {
-        this.statusCode = statusCode;
-    }
-
-    public MacroData getData() {
-        return data;
-    }
-
-    public void setData(MacroData data) {
-        this.data = data;
-    }
-
-    public static class MacroData {
-        private String answer;
-        private String url;
-
-        public MacroData(String answer, String url) {
-            this.answer = answer;
-            this.url = url;
-        }
-
-        public String getAnswer() {
-            return answer;
-        }
-
-        public void setAnswer(String answer) {
-            this.answer = answer;
-        }
-
-        public String getUrl() {
-            return url;
-        }
-
-        public void setUrl(String url) {
-            this.url = url;
-        }
-    }
+public record MacroResponse(
+        int statusCode,
+        CaptchaResult data
+) {
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/auth/service/CaptchaService.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/auth/service/CaptchaService.java
@@ -1,0 +1,48 @@
+package com.tutorialsejong.courseregistration.domain.auth.service;
+
+import cn.apiclub.captcha.Captcha;
+import cn.apiclub.captcha.backgrounds.BackgroundProducer;
+import cn.apiclub.captcha.text.producer.NumbersAnswerProducer;
+import cn.apiclub.captcha.text.renderer.WordRenderer;
+import com.tutorialsejong.courseregistration.domain.auth.dto.CaptchaResult;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import javax.imageio.ImageIO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CaptchaService {
+
+    private static final int CAPTCHA_WIDTH = 200;
+    private static final int CAPTCHA_HEIGHT = 80;
+    private static final int CAPTCHA_LENGTH = 4;
+
+    private final WordRenderer wordRenderer;
+    private final BackgroundProducer backgroundProducer;
+
+    public CaptchaResult generateCaptcha() {
+        Captcha captcha = new Captcha.Builder(CAPTCHA_WIDTH, CAPTCHA_HEIGHT)
+                .addBackground(backgroundProducer)
+                .addText(new NumbersAnswerProducer(CAPTCHA_LENGTH), wordRenderer)
+                .build();
+
+        String base64Image = convertToBase64(captcha.getImage());
+        String imageUrl = "data:image/png;base64," + base64Image;
+
+        return new CaptchaResult(captcha.getAnswer(), imageUrl);
+    }
+
+    private String convertToBase64(BufferedImage image) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(image, "png", baos);
+            return Base64.getEncoder().encodeToString(baos.toByteArray());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to convert image to Base64", e);
+        }
+    }
+}


### PR DESCRIPTION
## 📋 이슈 번호
[TS-35](https://jeez.atlassian.net/browse/TS-35?atlOrigin=eyJpIjoiNjYzN2E1MGM3YTA5NGI1NWI3Zjk1Zjg0Y2E5MzI0YTUiLCJwIjoiaiJ9)

## ✅ 변경 사항
- 기존 Captcha 구현을 Simple Captcha 라이브러리로 대체했습니다.


## 📝 세부 설명
- Simple Captcha 라이브러리로 Base64 이미지를 동적으로 생성해 보내고 있기 때문에 이미지 파일 저장/관리가 불필요해졌습니다.
- macro api는 기존과 같습니다.
- 하지만 응답의 "url" 값이 기존에는 "/macro/4.jpg"와 같은 이미지 파일 경로였으나, 이제는 "data:image/png;base64,..."와 같은 Base64 인코딩된 이미지 데이터로 변경되었습니다. 따라서 프론트엔드에서는 별도로 이미지 요청을 하지 않고 해당 데이터를 직접 이미지 태그의 src로 사용하도록 변경해야 합니다.

### 이전
```json
{
    "statusCode": 200,
    "data": {
        "answer": "2857",
        "url": "/macro/4.jpg"
    }
}
```

### 이후
```json
{
    "statusCode": 200,
    "data": {
        "answer": "2857",
        "url": "data:image/png;base64,..."
    }
}
```



[TS-35]: https://jeez.atlassian.net/browse/TS-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ