### PR TITLE
feat(TS-48): 인기 강좌 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.tutorialsejong.courseregistration.domain.schedule.controller;
 
 import com.tutorialsejong.courseregistration.domain.schedule.dto.ErrorDto;
+import com.tutorialsejong.courseregistration.domain.schedule.dto.ScheduleResponse;
 import com.tutorialsejong.courseregistration.domain.schedule.dto.ScheduleSearchRequest;
 import com.tutorialsejong.courseregistration.domain.schedule.entity.Schedule;
 import com.tutorialsejong.courseregistration.domain.schedule.service.ScheduleService;
@@ -19,6 +20,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.WebRequest;
 
@@ -27,7 +29,8 @@ import org.springframework.web.context.request.WebRequest;
 public class ScheduleController {
 
     private static final Set<String> ALLOWED_PARAMS = Set.of(
-            "curiNo", "classNo", "schCollegeAlias", "schDeptAlias", "curiTypeCdNm", "sltDomainCdNm", "curiNm", "lesnEmp", "studentId"
+            "curiNo", "classNo", "schCollegeAlias", "schDeptAlias", "curiTypeCdNm", "sltDomainCdNm", "curiNm",
+            "lesnEmp", "studentId"
     );
 
     private final ScheduleService scheduleService;
@@ -68,5 +71,12 @@ public class ScheduleController {
     private ResponseEntity<ErrorDto> createErrorResponse(HttpStatus status, String message, WebRequest request) {
         return ResponseEntity.status(status)
                 .body(new ErrorDto(new Date(), status.value(), message, request.getDescription(false)));
+    }
+
+    @GetMapping("/popular")
+    public ResponseEntity<List<ScheduleResponse>> getPopularSchedules(
+            @RequestParam(defaultValue = "10") int limit) {
+        List<ScheduleResponse> popularSchedules = scheduleService.findPopularSchedules(limit);
+        return ResponseEntity.ok(popularSchedules);
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/dto/ScheduleResponse.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/dto/ScheduleResponse.java
@@ -1,0 +1,36 @@
+package com.tutorialsejong.courseregistration.domain.schedule.dto;
+
+import com.tutorialsejong.courseregistration.domain.schedule.entity.Schedule;
+
+public record ScheduleResponse(
+        Long scheduleId,
+        String curiNm,          // 과목명
+        String curiNo,          // 과목번호
+        String classNo,         // 분반
+        String manageDeptNm,    // 개설학과
+        String lesnEmp,         // 담당교수
+        String lesnTime,        // 강의시간
+        String lesnRoom,        // 강의실
+        Long wishCount,         // 관심과목 수
+        Integer rank           // 순위
+) {
+    public static ScheduleResponse from(Schedule schedule, Integer rank) {
+        return new ScheduleResponse(
+                schedule.getScheduleId(),
+                schedule.getCuriNm(),
+                schedule.getCuriNo(),
+                schedule.getClassNo(),
+                schedule.getManageDeptNm(),
+                schedule.getLesnEmp(),
+                schedule.getLesnTime(),
+                schedule.getLesnRoom(),
+                schedule.getWishCount(),
+                rank
+        );
+    }
+
+    // rank 없는 버전의 from 메서드 - 일반 과목 조회시 사용
+    public static ScheduleResponse from(Schedule schedule) {
+        return from(schedule, null);
+    }
+}

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/entity/Schedule.java
@@ -1,9 +1,18 @@
 package com.tutorialsejong.courseregistration.domain.schedule.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "course_schedule")
+@Getter
+@NoArgsConstructor
 public class Schedule {
 
     @Id
@@ -67,83 +76,14 @@ public class Schedule {
     @Column(name = "remark")
     private String remark;
 
-    public Long getScheduleId() {
-        return scheduleId;
+    @Column(name = "wish_count", nullable = false)
+    private Long wishCount = 0L;
+
+    public void incrementWishCount() {
+        this.wishCount++;
     }
 
-    public String getSchDeptAlias() {
-        return schDeptAlias;
-    }
-
-    public String getCuriNo() {
-        return curiNo;
-    }
-
-    public String getClassNo() {
-        return classNo;
-    }
-
-    public String getSchCollegeAlias() {
-        return schCollegeAlias;
-    }
-
-    public String getCuriNm() {
-        return curiNm;
-    }
-
-    public String getCuriLangNm() {
-        return curiLangNm;
-    }
-
-    public String getCuriTypeCdNm() {
-        return curiTypeCdNm;
-    }
-
-    public String getSltDomainCdNm() {
-        return sltDomainCdNm;
-    }
-
-    public String getTmNum() {
-        return tmNum;
-    }
-
-    public String getStudentYear() {
-        return studentYear;
-    }
-
-    public String getCorsUnitGrpCdNm() {
-        return corsUnitGrpCdNm;
-    }
-
-    public String getManageDeptNm() {
-        return manageDeptNm;
-    }
-
-    public String getLesnEmp() {
-        return lesnEmp;
-    }
-
-    public String getLesnTime() {
-        return lesnTime;
-    }
-
-    public String getLesnRoom() {
-        return lesnRoom;
-    }
-
-    public String getCyberTypeCdNm() {
-        return cyberTypeCdNm;
-    }
-
-    public String getInternshipTypeCdNm() {
-        return internshipTypeCdNm;
-    }
-
-    public String getInoutSubCdtExchangeYn() {
-        return inoutSubCdtExchangeYn;
-    }
-
-    public String getRemark() {
-        return remark;
+    public void decrementWishCount() {
+        this.wishCount = Math.max(0, this.wishCount - 1);
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/repository/ScheduleRepository.java
@@ -1,11 +1,11 @@
 package com.tutorialsejong.courseregistration.domain.schedule.repository;
 
 import com.tutorialsejong.courseregistration.domain.schedule.entity.Schedule;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
@@ -36,4 +36,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("curi_nm") String curiNm,
             @Param("lesn_emp") String lesnEmp
     );
+
+    List<Schedule> findAllByOrderByWishCountDesc(Pageable pageable);
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/schedule/service/ScheduleService.java
@@ -2,15 +2,19 @@ package com.tutorialsejong.courseregistration.domain.schedule.service;
 
 import com.tutorialsejong.courseregistration.domain.registration.entity.CourseRegistration;
 import com.tutorialsejong.courseregistration.domain.registration.repository.CourseRegistrationRepository;
+import com.tutorialsejong.courseregistration.domain.schedule.dto.ScheduleResponse;
 import com.tutorialsejong.courseregistration.domain.schedule.dto.ScheduleSearchRequest;
 import com.tutorialsejong.courseregistration.domain.schedule.entity.Schedule;
 import com.tutorialsejong.courseregistration.domain.schedule.repository.ScheduleRepository;
 import com.tutorialsejong.courseregistration.domain.user.entity.User;
 import com.tutorialsejong.courseregistration.domain.user.exception.UserNotFoundException;
 import com.tutorialsejong.courseregistration.domain.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,7 +34,7 @@ public class ScheduleService {
 
     public List<Schedule> getSearchResultSchedules(ScheduleSearchRequest scheduleSearchRequest, String studentId) {
         User user = userRepository.findByStudentId(studentId)
-                .orElseThrow(() -> new UserNotFoundException());
+                .orElseThrow(UserNotFoundException::new);
 
         List<Schedule> findAllByResult = scheduleRepository.findAllBy(
                 scheduleSearchRequest.curiNo(),
@@ -45,10 +49,33 @@ public class ScheduleService {
 
         List<Schedule> registeredSchedules = courseRegistrationRepository.findAllByStudent(user).stream()
                 .map(CourseRegistration::getSchedule)
-                .collect(Collectors.toList());
+                .toList();
 
         return findAllByResult.stream()
                 .filter(schedule -> !registeredSchedules.contains(schedule))
                 .collect(Collectors.toList());
+    }
+
+    public List<ScheduleResponse> findPopularSchedules(int limit) {
+        List<Schedule> schedules = scheduleRepository.findAllByOrderByWishCountDesc(PageRequest.of(0, limit));
+
+        if (schedules.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<ScheduleResponse> responses = new ArrayList<>();
+        int currentRank = 1;
+        Long previousWishCount = null;
+
+        for (Schedule schedule : schedules) {
+            if (previousWishCount != null && !schedule.getWishCount().equals(previousWishCount)) {
+                currentRank++;
+            }
+
+            responses.add(ScheduleResponse.from(schedule, currentRank));
+            previousWishCount = schedule.getWishCount();
+        }
+
+        return responses;
     }
 }

--- a/src/main/java/com/tutorialsejong/courseregistration/domain/wishlist/service/WishListService.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/domain/wishlist/service/WishListService.java
@@ -14,12 +14,10 @@ import com.tutorialsejong.courseregistration.domain.user.exception.UserNotFoundE
 import com.tutorialsejong.courseregistration.domain.user.repository.UserRepository;
 import com.tutorialsejong.courseregistration.domain.wishlist.entity.WishList;
 import com.tutorialsejong.courseregistration.domain.wishlist.exception.AlreadyInWishlistException;
-import com.tutorialsejong.courseregistration.domain.wishlist.exception.WishlistCourseAlreadyRegisteredException;
 import com.tutorialsejong.courseregistration.domain.wishlist.exception.WishlistNotFoundException;
 import com.tutorialsejong.courseregistration.domain.wishlist.repository.WishListRepository;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -47,8 +45,8 @@ public class WishListService {
     public void saveWishListItem(String studentId, Long scheduleId) {
         logger.info(LogMessage.builder()
                 .action(LogAction.ADD_WISHLIST)
-                .subject("s"+studentId)
-                .objectName("c"+scheduleId)
+                .subject("s" + studentId)
+                .objectName("c" + scheduleId)
                 .result(LogResult.SUCCESS)
                 .extras("Starting wishlist addition")
                 .build().toString());
@@ -64,8 +62,8 @@ public class WishListService {
         if (existsInWishList) {
             logger.warn(LogMessage.builder()
                     .action(LogAction.ADD_WISHLIST)
-                    .subject("s"+studentId)
-                    .objectName("c"+scheduleId)
+                    .subject("s" + studentId)
+                    .objectName("c" + scheduleId)
                     .result(LogResult.FAIL)
                     .reason(LogReason.ALREADY_EXIST)
                     .build().toString());
@@ -74,10 +72,14 @@ public class WishListService {
 
         WishList newWishList = new WishList(user, schedule);
         wishListRepository.save(newWishList);
+
+        schedule.incrementWishCount();
+        scheduleRepository.save(schedule);
+        
         logger.info(LogMessage.builder()
                 .action(LogAction.ADD_WISHLIST)
-                .subject("s"+studentId)
-                .objectName("c"+scheduleId)
+                .subject("s" + studentId)
+                .objectName("c" + scheduleId)
                 .result(LogResult.SUCCESS)
                 .extras("Successfully added to wishlist")
                 .build().toString());
@@ -86,7 +88,7 @@ public class WishListService {
     public List<Schedule> getWishList(String studentId) {
         logger.info(LogMessage.builder()
                 .action(LogAction.FETCH_REGISTERED_COURSES)
-                .subject("s"+studentId)
+                .subject("s" + studentId)
                 .result(LogResult.SUCCESS)
                 .extras("Fetching wishlist")
                 .build().toString());
@@ -97,7 +99,7 @@ public class WishListService {
 
         logger.info(LogMessage.builder()
                 .action(LogAction.FETCH_REGISTERED_COURSES)
-                .subject("s"+studentId)
+                .subject("s" + studentId)
                 .result(LogResult.SUCCESS)
                 .extras("Wishlist fetched successfully")
                 .build().toString());
@@ -112,7 +114,7 @@ public class WishListService {
     public User checkExistUser(String studentId) {
         logger.info(LogMessage.builder()
                 .action(LogAction.VALIDATE_USER)
-                .subject("s"+studentId)
+                .subject("s" + studentId)
                 .result(LogResult.SUCCESS)
                 .extras("Validating user existence")
                 .build().toString());
@@ -121,7 +123,7 @@ public class WishListService {
                 .orElseThrow(() -> {
                     logger.warn(LogMessage.builder()
                             .action(LogAction.VALIDATE_USER)
-                            .subject("s"+studentId)
+                            .subject("s" + studentId)
                             .result(LogResult.FAIL)
                             .reason(LogReason.NOT_FOUND)
                             .extras("User not found")
@@ -133,7 +135,7 @@ public class WishListService {
     public Schedule checkExistSchedule(Long scheduleId) {
         logger.info(LogMessage.builder()
                 .action(LogAction.VALIDATE_COURSE)
-                .objectName("c"+scheduleId)
+                .objectName("c" + scheduleId)
                 .result(LogResult.SUCCESS)
                 .extras("Validating schedule existence")
                 .build().toString());
@@ -142,7 +144,7 @@ public class WishListService {
                 .orElseThrow(() -> {
                     logger.warn(LogMessage.builder()
                             .action(LogAction.VALIDATE_COURSE)
-                            .objectName("c"+scheduleId)
+                            .objectName("c" + scheduleId)
                             .result(LogResult.FAIL)
                             .reason(LogReason.NOT_FOUND)
                             .extras("Schedule not found")
@@ -154,8 +156,8 @@ public class WishListService {
     public void deleteWishListItem(String studentId, Long scheduleId) {
         logger.info(LogMessage.builder()
                 .action(LogAction.REMOVE_WISHLIST) // 추가된 LogAction
-                .subject("s"+studentId)
-                .objectName("c"+scheduleId)
+                .subject("s" + studentId)
+                .objectName("c" + scheduleId)
                 .result(LogResult.SUCCESS)
                 .extras("Starting removal of wishlist item")
                 .build().toString());
@@ -167,8 +169,8 @@ public class WishListService {
                 .orElseThrow(() -> {
                     logger.warn(LogMessage.builder()
                             .action(LogAction.REMOVE_WISHLIST)
-                            .subject("s"+studentId)
-                            .objectName("c"+scheduleId)
+                            .subject("s" + studentId)
+                            .objectName("c" + scheduleId)
                             .result(LogResult.FAIL)
                             .reason(LogReason.NOT_FOUND)
                             .extras("Wishlist item not found")
@@ -177,10 +179,14 @@ public class WishListService {
                 });
 
         wishListRepository.delete(wishList);
+
+        schedule.decrementWishCount();
+        scheduleRepository.save(schedule);
+
         logger.info(LogMessage.builder()
                 .action(LogAction.REMOVE_WISHLIST)
-                .subject("s"+studentId)
-                .objectName("c"+scheduleId)
+                .subject("s" + studentId)
+                .objectName("c" + scheduleId)
                 .result(LogResult.SUCCESS)
                 .extras("Removed wishlist item")
                 .build().toString());
@@ -189,7 +195,7 @@ public class WishListService {
     public void deleteWishListsByStudent(String studentId) {
         logger.info(LogMessage.builder()
                 .action(LogAction.REMOVE_WISHLIST)
-                .subject("s"+studentId)
+                .subject("s" + studentId)
                 .result(LogResult.SUCCESS)
                 .extras("Starting removal of all wishlist items for the user")
                 .build().toString());
@@ -198,7 +204,7 @@ public class WishListService {
 
         logger.info(LogMessage.builder()
                 .action(LogAction.REMOVE_WISHLIST)
-                .subject("s"+studentId)
+                .subject("s" + studentId)
                 .result(LogResult.SUCCESS)
                 .extras("Removed all wishlist items for the user")
                 .build().toString());


### PR DESCRIPTION
## 📋 이슈 번호
[TS-48](https://jeez.atlassian.net/browse/TS-48)


## ✅ 변경 사항
- Schedule 엔티티에 wish_count 필드와 관리 메서드 추가
- 관심과목 등록/삭제 시 wish_count 자동 업데이트 로직 구현
- 인기 강좌 조회 API 구현

## 📝 세부 설명

### API 명세
API 명세는 노션에도 남겨놨습니다!

#### Request
- **URL**: `GET /schedules/popular`
- **Query Parameters**:
  - `limit`: 조회할 강좌 수 (기본값: 10)

#### Response
- **Status**: 200 (OK)
- **Content-Type**: `application/json`

```json
[
    {
        "scheduleId": 1,
        "curiNm": "컴퓨터과학개론",     // 과목명
        "curiNo": "101",              // 과목번호
        "classNo": "01",              // 분반
        "manageDeptNm": "컴퓨터공학과", // 개설학과
        "lesnEmp": "홍길동",           // 담당교수
        "lesnTime": "월수금 9:00-10:30", // 강의시간
        "lesnRoom": "공학관 101호",     // 강의실
        "wishCount": 10,              // 관심과목 수
        "rank": 1                     // 순위
    }
]
```

### 조회된 강좌가 없는 경우

- 빈 리스트 반환

### 순위가 모두 똑같은 경우

- 스케쥴 id순으로 반환



[TS-48]: https://jeez.atlassian.net/browse/TS-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ