### PR TITLE
refactor(TS-51): CORS 설정을 application.properties로 분리

### DIFF
--- a/src/main/java/com/tutorialsejong/courseregistration/common/config/SecurityConfig.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.tutorialsejong.courseregistration.common.security.JwtExceptionFilter;
 import com.tutorialsejong.courseregistration.common.security.JwtTokenProvider;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -25,6 +26,12 @@ import org.springframework.web.cors.CorsConfiguration;
 @EnableWebSecurity
 public class SecurityConfig {
 
+    @Value("${security.cors.allowed-origins}")
+    private String[] allowedOrigins;
+
+    @Value("${security.cors.allow-credentials}")
+    private boolean allowCredentials;
+
     private final JwtTokenProvider tokenProvider;
 
     @Bean
@@ -38,12 +45,10 @@ public class SecurityConfig {
                 .cors(cors -> cors
                         .configurationSource(request -> {
                             CorsConfiguration config = new CorsConfiguration();
-                            config.setAllowedOrigins(
-                                    Arrays.asList("https://tutorial-sejong.com", "https://frontend.local.com:3000",
-                                            "http://localhost:3000"));
+                            config.setAllowedOrigins(Arrays.asList(allowedOrigins));
+                            config.setAllowCredentials(allowCredentials);
                             config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                             config.setAllowedHeaders(Arrays.asList("*"));
-                            config.setAllowCredentials(true);
                             return config;
                         })
                 )


### PR DESCRIPTION
## 📋 이슈 번호
[TS-51](https://jeez.atlassian.net/browse/TS-51)

## ✅ 변경 사항
- SecurityConfig에서 하드코딩된 CORS 설정값들을 application.properties로 이동
  - allowed-origins를 properties로 분리
  - allow-credentials를 properties로 분리

## 📝 세부 설명
기존에 CORS allowed-origins가 SecurityConfig에 하드코딩 되어 환경별로 다른 origins 적용이 어려웠습니다.
applications.properties에 값을 입력하고 `@Value`로 주입받게 하여 환경별로 적용할 수 있게 개선했습니다.

1. application.properties에 CORS 관련 설정 추가
   - security.cors.allowed-origins
   - security.cors.allow-credentials

2. SecurityConfig 클래스에서 `@Value`로 주입받아 사용하도록 변경


[TS-51]: https://jeez.atlassian.net/browse/TS-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ