### PR TITLE
fix(TS-53): 만료 토큰 로깅 처리 개선

### DIFF
--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/JwtTokenProvider.java
@@ -15,7 +15,6 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Date;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -85,19 +84,19 @@ public class JwtTokenProvider {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
         } catch (ExpiredJwtException ex) {
-            String username = getUsernameFromJWT(token);
+            String username = ex.getClaims().getSubject();
             logger.warn(LogMessage.builder()
-                            .action(LogAction.VALIDATE_TOKEN)
-                            .subject("s"+username)
-                            .result(LogResult.FAIL)
-                            .reason(LogReason.EXPIRED)
+                    .action(LogAction.VALIDATE_TOKEN)
+                    .subject("s" + username)
+                    .result(LogResult.FAIL)
+                    .reason(LogReason.EXPIRED)
                     .build().toString());
             throw new JwtTokenExpiredException();
         } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException ex) {
             String username = getUsernameFromJWT(token);
             logger.warn(LogMessage.builder()
                     .action(LogAction.VALIDATE_TOKEN)
-                    .subject("s"+username)
+                    .subject("s" + username)
                     .result(LogResult.FAIL)
                     .reason(LogReason.INVALID_CREDENTIAL)
                     .build().toString());


### PR DESCRIPTION
## 📋 이슈 번호
[TS-53](https://jeez.atlassian.net/browse/TS-53)

## ✅ 변경 사항
- 만료된 토큰 검증 시 S002 에러가 정상적으로 반환되도록 수정하였습니다.
- 토큰 만료 시 로깅 처리 방식을 개선하였습니다.

## 📝 세부 설명
### 문제점
로깅을 위해 username을 가져오는 과정에서 무한 재귀가 발생하였습니다. 때문에 S002 에러코드가 올바르게 가지 못하고 있었습니다.

   ```java
   // validateToken 메소드
   catch (ExpiredJwtException ex) {
       String username = getUsernameFromJWT(token);  // 1. 만료된 토큰으로 getUsernameFromJWT 호출
       logger.warn(LogMessage.builder()...
   }

   // getUsernameFromJWT 메소드
   public String getUsernameFromJWT(String token) {
       validateToken(token); // 2. 다시 validateToken 호출하여 무한 재귀 발생
       Claims claims = Jwts.parserBuilder()
               .setSigningKey(key)
               .build()
               .parseClaimsJws(token)
               .getBody();
       return claims.getSubject();
   }
   ```

토큰이 만료되어 ExpiredJwtException이 발생했음에도, 로깅을 위해 getUsernameFromJWT를 호출하면서 무한 재귀가 발생하는 문제가 있었습니다.

### 해결
ExpiredJwtException이 발생할 때 이미 파싱된 claims 정보를 가지고 있으므로, 이를 직접 활용하도록 수정하였습니다.

   ```java
   catch (ExpiredJwtException ex) {
       String username = ex.getClaims().getSubject();  // 이미 파싱된 정보 활용
       logger.warn(LogMessage.builder()...
   ```

[TS-53]: https://jeez.atlassian.net/browse/TS-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ