### PR TITLE
refactor(TS-54): 에러코드 네이밍 수정

### DIFF
--- a/src/main/java/com/tutorialsejong/courseregistration/common/exception/GlobalErrorCode.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/exception/GlobalErrorCode.java
@@ -14,7 +14,7 @@ public enum GlobalErrorCode implements ErrorCode {
     METHOD_NOT_ALLOWED("G004", "허용되지 않는 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
     HANDLE_ACCESS_DENIED("G005", "접근이 거부되었습니다.", HttpStatus.FORBIDDEN),
     UNAUTHORIZED("G006", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
-    TOO_MANY_REQUESTS("G006", "과도한 요청을 보내셨습니다. 잠시 기다려 주세요.", HttpStatus.TOO_MANY_REQUESTS);
+    TOO_MANY_REQUESTS("G007", "과도한 요청을 보내셨습니다. 잠시 기다려 주세요.", HttpStatus.TOO_MANY_REQUESTS);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/SecurityErrorCode.java
+++ b/src/main/java/com/tutorialsejong/courseregistration/common/security/exception/SecurityErrorCode.java
@@ -9,9 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SecurityErrorCode implements ErrorCode {
 
-    AUTHENTICATION_FAILED("S001", "인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
-    JWT_TOKEN_EXPIRED("S002", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
-    JWT_TOKEN_INVALID("S003", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    AUTHENTICATION_FAILED("A001", "인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    JWT_TOKEN_EXPIRED("A002", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    JWT_TOKEN_INVALID("A003", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     ;
 
     private final String code;


### PR DESCRIPTION
## 📋 이슈 번호
[TS-54](https://jeez.atlassian.net/browse/TS-54)

## ✅ 변경 사항
- SecurityErrorCode와 ScheduleErrorCode의 중복을 피하기 위해 SecurityErrorCode의 접두사를 Auth의 A로 바꿨습니다.
- GlobalErrorCode에 G006이 중복돼 있던 것을 수정했습니다.

[TS-54]: https://jeez.atlassian.net/browse/TS-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ